### PR TITLE
Update ssh keys path to the right path

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -37,7 +37,7 @@ const startAppServer = (
     setPass(adminPass)
 
     if (isProduction()) {
-      fs.readFile('/home/myproxy/.ssh/authorized_keys', (error, data) => {
+      fs.readFile('/home/git/.ssh/authorized_keys', (error, data) => {
         if (error) {
           console.log(error)
         }


### PR DESCRIPTION
This PR will fix the path that is used by myproxy at startup so that it it gets all the old keys right.

Here, we can see the path that gets updated with the new keys is indeed `/home/git/.ssh/authorized_keys`: https://github.com/garageScript/myProxy/blob/ce94f9976d57ce3b0faaabfb79877abc7dd025ba/src/helpers/authorizedKeys.ts#L15-L17